### PR TITLE
use spatial index to speed up

### DIFF
--- a/lib/methods/areal-weighting.js
+++ b/lib/methods/areal-weighting.js
@@ -3,6 +3,7 @@
 const Turf = require('turf');
 const Logger = require('../logger');
 const isUndefined = require('lodash/isUndefined');
+const rbush = require('rbush');
 
 function main(source, target, options) {
   target.features.forEach((d, i) => {
@@ -18,6 +19,7 @@ function arealWeighting(feature, source, options, attributeName) {
   const intersectData = getIntersectingFeatures(source.features, feature);
   const sourceFeatures = intersectData[0];
   const intersects = intersectData[1];
+  
 
   intersects.forEach((d,i) => {
     const Ps = parseFloat(sourceFeatures[i].properties[attributeName]);
@@ -32,18 +34,48 @@ function arealWeighting(feature, source, options, attributeName) {
 
 function getIntersectingFeatures(sourceFeatures, targetFeature) {
   let intersects = [];
-  let featureSimpl = targetFeature;
+  let sourceList = [];  // source features that got intersected?
+  
+  /* Create and fill the bushy tree */
+  var tree = rbush();
+  let items = [];
+  
+  for (var i=0; i<sourceFeatures.length; i++) {
+    var bbox = Turf.extent(sourceFeatures[i]);
+    var item = {
+      minX: bbox[0],
+      minY: bbox[1],
+      maxX: bbox[2],
+      maxY: bbox[3],
+      index: i
+    };
+    items.push(item);
+  }
+  
+  tree.load(items);
 
-  const sourceList = sourceFeatures.filter(f => {
-    let intersection = Turf.intersect(featureSimpl, f);
+  /* Quickly get the likely candidates that might intersect */
+  var bbox = Turf.extent(targetFeature);
+  var candidates = tree.search({
+    minX: bbox[0],
+    minY: bbox[1],
+    maxX: bbox[2],
+    maxY: bbox[3]
+  });
+  
+  /* Check the candidates for actual intersection and do the rest */
+  for (var i=0; i<candidates.length; i++) {
+    var index = candidates[i].index;
+    var f = sourceFeatures[index];
+    
+    let intersection = Turf.intersect(targetFeature, f);
 
     if(!isUndefined(intersection)) {
       intersection.properties = f.properties;
       intersects.push(intersection);
+      sourceList.push(f);
     }
-
-    return !isUndefined(intersection);
-  });
+  }
 
   return [sourceList, intersects];
 }


### PR DESCRIPTION
I worked with rtree in Python recently so the logic was easy to transfer. Don't judge my code, I *hate* JavaScript and have no idea about anything. **Please don't merge it like this**, it looks ugly as hell. :]

Adds rbush as dependency!

Results seem identical up to 9-10 places so perfectly fine. https://gist.github.com/fnorf/38e789f37619f47dc9826d848546e1be

Before:
real	3m37.833s
user	3m39.787s
sys	0m0.310s

After:
real	0m34.675s
user	0m35.260s
sys	0m0.160s

Weeeeeeeeeeeeeeeeee! :))))))))))))